### PR TITLE
Add eos_token to FinishReason

### DIFF
--- a/src/mistralai/models/chat_completion.py
+++ b/src/mistralai/models/chat_completion.py
@@ -61,6 +61,7 @@ class FinishReason(str, Enum):
     length = "length"
     error = "error"
     tool_calls = "tool_calls"
+    eos_token = "eos_token"
 
 
 class ChatCompletionResponseStreamChoice(BaseModel):


### PR DESCRIPTION
Solves issue caused when using TGI:

```
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatCompletionResponse
choices.0.finish_reason
  Input should be 'stop', 'length', 'error' or 'tool_calls' [type=enum, input_value='eos_token', input_type=str]

```